### PR TITLE
[In Progress] 2.0

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Trello Cycle Time Tracker",
-  "version": "1.0",
+  "version": "2.0",
   "description": "Stay on top of your team's cycle time with visual indications of card age and progression.",
   "background": {
     "scripts": ["src/background_scripts/main.js"],

--- a/src/background_scripts/main.js
+++ b/src/background_scripts/main.js
@@ -9,8 +9,8 @@
   *     boardId: {
   *       enabled: boolean,
   *       targetCycleTime: 60,
-  *       cycleTimeRelatedColumns: [...],
-  *       startingColumnId: '...'
+  *       unstartedListSuffix: '...',
+  *       startedListSuffix: '...'
   *     }
   *   }
   * }
@@ -22,8 +22,8 @@ var DEFAULT_SETTINGS = {
 var DEFAULT_INDIVIDUAL_BOARD_SETTINGS = {
   enabled: false,
   targetCycleTimeMinutes: 60,
-  cycleTimeRelatedColumns: [], // [{ id: '...', name: '...'  }, ...]
-  startingColumnId: null
+  unstartedListSuffix: '^',
+  startedListSuffix: '*'
 };
 
 // ensure that there are some settings for the extension

--- a/src/content_scripts/main.js
+++ b/src/content_scripts/main.js
@@ -70,7 +70,12 @@ function getActionsForCard(cardId, cb) {
 // returns the timestamp of the most recent time that the card
 // entered a list with the specified suffix
 function parseMostRecentEnterTimeToListsWithSuffix(actions, suffix) {
-  var time = actions[0] ? new Date(actions[0].date) : new Date();
+  var time;
+  if (actions.length > 0) {
+    time = new Date(actions[actions.length - 1].date);
+  } else {
+    time = new Date();
+  }
 
   for (var i = 0; i < actions.length; i++) {
     if (actions[i].data && actions[i].data.listAfter && actions[i].data.listBefore) {
@@ -87,7 +92,12 @@ function parseMostRecentEnterTimeToListsWithSuffix(actions, suffix) {
 // returns the timestamp of the most recent time that the card
 // left a list with any of the specified suffixes
 function parseMostRecentExitTimeFromListsWithSuffixes(actions, suffixes) {
-  var time = actions[0] ? new Date(actions[0].date) : new Date();
+  var time;
+  if (actions.length > 0) {
+    time = new Date(actions[actions.length - 1].date);
+  } else {
+    time = new Date();
+  }
 
   var endsWithAny = function(str, suffixes) {
     return suffixes.some(function(suffix) {
@@ -211,7 +221,6 @@ ContentManager.prototype.retrieveTrelloLists = function(cb) {
 };
 
 ContentManager.prototype.retrieveTrelloActionsForCard = function(cardId, cb) {
-  var self = this;
   this.executor.execute(function() {
     getActionsForCard(cardId, function(actions) {
 

--- a/src/content_scripts/main.js
+++ b/src/content_scripts/main.js
@@ -68,13 +68,13 @@ function getActionsForCard(cardId, cb) {
 }
 
 // returns the timestamp of the most recent time that the card
-// entered one of the specified lists
-function parseMostRecentEnterTimeToListsFromActions(actions, listIds) {
+// entered a list with the specified suffix
+function parseMostRecentEnterTimeToListsWithSuffix(actions, suffix) {
   var time = actions[0] ? new Date(actions[0].date) : new Date();
 
   for (var i = 0; i < actions.length; i++) {
     if (actions[i].data && actions[i].data.listAfter && actions[i].data.listBefore) {
-      if (listIds.indexOf(actions[i].data.listAfter.id) !== -1 && listIds.indexOf(actions[i].data.listBefore.id) === -1) {
+      if (actions[i].data.listAfter.name.endsWith(suffix) && !actions[i].data.listBefore.name.endsWith(suffix)) {
         time = new Date(actions[i].date);
         break;
       }
@@ -85,13 +85,20 @@ function parseMostRecentEnterTimeToListsFromActions(actions, listIds) {
 }
 
 // returns the timestamp of the most recent time that the card
-// exited one of the specified lists
-function parseMostRecentExitTimeFromListsFromActions(actions, listIds) {
+// left a list with any of the specified suffixes
+function parseMostRecentExitTimeFromListsWithSuffixes(actions, suffixes) {
   var time = actions[0] ? new Date(actions[0].date) : new Date();
+
+  var endsWithAny = function(str, suffixes) {
+    return suffixes.some(function(suffix) {
+      return str.endsWith(suffix);
+    });
+  }
 
   for (var i = 0; i < actions.length; i++) {
     if (actions[i].data && actions[i].data.listAfter && actions[i].data.listBefore) {
-      if (listIds.indexOf(actions[i].data.listAfter.id) === -1 && listIds.indexOf(actions[i].data.listBefore.id) !== -1) {
+      if(!endsWithAny(actions[i].data.listAfter.name, suffixes)
+          && endsWithAny(actions[i].data.listBefore.name, suffixes)) {
         time = new Date(actions[i].date);
         break;
       }
@@ -164,12 +171,12 @@ ContentManager.prototype.update = function() {
           return $(this).text() === listWithCards.name;
         }).closest(TRELLO_LIST_SELECTOR);
 
-        var cycleTimeListIds = self.settings.cycleTimeRelatedColumns.map(function (l) { return l.id });
-        var isCycleTimeList = cycleTimeListIds.indexOf(listWithCards.id) !== -1;
+        var unstartedListSuffix = self.settings.unstartedListSuffix;
+        var startedListSuffix = self.settings.startedListSuffix;
 
-        if (isCycleTimeList) {
+        if (listWithCards.name.endsWith(startedListSuffix)) {
           self.updateInProgressCardsInList($currentList, listWithCards);
-        } else if (listWithCards.id === self.settings.startingColumnId) { // non starting column, i.e. completed
+        } else if (listWithCards.name.endsWith(unstartedListSuffix)) {
           self.resetCardsInList($currentList);
         } else {
           self.markCardsInListAsCompleted($currentList, listWithCards);
@@ -355,8 +362,7 @@ ContentManager.prototype.assignStartTimesForCardsInList = function (listWithCard
 
     if (!(self.cardIdToTimeStartedMap[cardId] && self.cardIdToTimeStartedMap[cardId].startedAt)) {
       self.retrieveTrelloActionsForCard(card.id, function(actions) {
-        var cycleTimeListIds = self.settings.cycleTimeRelatedColumns.map(function (list) { return list.id });
-        var startTime = parseMostRecentEnterTimeToListsFromActions(actions, cycleTimeListIds);
+        var startTime = parseMostRecentEnterTimeToListsWithSuffix(actions, self.settings.startedListSuffix);
 
         self.cardIdToTimeStartedMap[cardId] = self.cardIdToTimeStartedMap[cardId] || {};
         self.cardIdToTimeStartedMap[cardId].startedAt = startTime;
@@ -386,16 +392,20 @@ ContentManager.prototype.assignCompletedTimesForCardsInList = function (listWith
 
     if (!self.cardIdToTimeStartedMap[cardId] || (!self.cardIdToTimeStartedMap[cardId].completedAt)) {
       self.retrieveTrelloActionsForCard(card.id, function(actions) {
-        var cycleTimeListIds = self.settings.cycleTimeRelatedColumns.map(function (list) { return list.id });
-        var exitTime = parseMostRecentExitTimeFromListsFromActions(actions, cycleTimeListIds.concat(self.settings.startingColumnId));
+        var exitTime = parseMostRecentExitTimeFromListsWithSuffixes(
+          actions,
+          [
+            self.settings.unstartedListSuffix,
+            self.settings.startedListSuffix
+          ]
+        );
 
         self.cardIdToTimeStartedMap[cardId] = self.cardIdToTimeStartedMap[cardId] || {};
         self.cardIdToTimeStartedMap[cardId].completedAt = exitTime;
 
         // ensures every completed card also has a start time
         if (!self.cardIdToTimeStartedMap[cardId].startedAt) {
-          var cycleTimeListIds = self.settings.cycleTimeRelatedColumns.map(function (list) { return list.id });
-          var startTime = parseMostRecentEnterTimeToListsFromActions(actions, cycleTimeListIds);
+          var startTime = parseMostRecentEnterTimeToListsWithSuffix(actions, self.settings.startedListSuffix);
           self.cardIdToTimeStartedMap[cardId].startedAt = startTime;
         }
 

--- a/src/popup.html
+++ b/src/popup.html
@@ -26,7 +26,7 @@
     <h3>Settings for Current Board</h3>
     <div class="row">
       <div class="col-sm">
-        <label for="target_ct"><b>Target cycle time in hrs (per card, defaults to 1)</b></label>
+        <label for="target_ct"><b>Target cycle time (hrs)</b></label>
         <input id="target_ct" type="text" class="form-control" />
       </div>
     </div>
@@ -34,21 +34,22 @@
     <br/>
 
     <div class="row">
-      <div class="col-sm js-starting-column-container">
-        <label><b>Select starting column (not yet started)</b></label>
+      <div class="col-sm">
+        <label for="unstarted_suffix"><b>Select unstarted column suffix</b></label>
+        <input id="unstarted_suffix" type="text" class="form-control" />
       </div>
     </div>
 
     <br />
 
     <div class="row">
-      <!-- dynamically generated -->
-      <div class="col-sm js-list-checkbox-container">
-        <label><b>Select columns to track</b></label>
+      <div class="col-sm">
+        <label for="started_suffix"><b>Select started/in-progress column suffix</b></label>
+        <input id="started_suffix" type="text" class="form-control" />
       </div>
     </div>
 
-    <div class="row mb-4">
+    <div class="row mt-3 mb-4">
       <div class="col-sm">
         <button id="submit_settings" class="btn btn-primary">Save</Button>
       </div>


### PR DESCRIPTION
Changes behavior of the extension to look for set suffixes instead of chosen lists. This update will need time to converge to correctness if list names are changed. This is because Trello stores the original name of lists with their actions, which means if a user changes a list's name, it will not be reflected when the extension attempts to parse times.

Because this change will cause previously computed times to be recomputed incorrectly if list name suffixes are changed, this is marked as a major version bump.

Changes:
- Users now specify suffixes for unstarted and started lists - all other lists are treated as completed
- Users can have multiple starting lists (by definition)
- Fixes #5 